### PR TITLE
Accelerate training convergence

### DIFF
--- a/latent_rationale/beer/models/latent.py
+++ b/latent_rationale/beer/models/latent.py
@@ -29,22 +29,23 @@ class LatentRationaleModel(nn.Module):
 
     """
     def __init__(self,
-                 vocab:          object = None,
-                 vocab_size:     int = 0,
-                 emb_size:       int = 200,
-                 hidden_size:    int = 200,
-                 output_size:    int = 1,
-                 dropout:        float = 0.1,
-                 layer:          str = "rcnn",
-                 dependent_z:    bool = True,
-                 z_rnn_size:     int = 30,
-                 selection:      float = 1.,
-                 lasso:          float = 0.,
-                 lagrange_alpha: float = 0.5,
-                 lagrange_lr:    float = 0.05,
-                 lambda_init:    float = 0.0015,
-                 lambda_min:     float = 1e-12,
-                 lambda_max:     float = 5.,
+                 vocab:              object = None,
+                 vocab_size:         int = 0,
+                 emb_size:           int = 200,
+                 hidden_size:        int = 200,
+                 output_size:        int = 1,
+                 dropout:            float = 0.1,
+                 layer:              str = "rcnn",
+                 dependent_z:        bool = True,
+                 z_rnn_size:         int = 30,
+                 selection:          float = 1.,
+                 lasso:              float = 0.,
+                 lagrange_alpha:     float = 0.5,
+                 lagrange_lr:        float = 0.05,
+                 lambda_init:        float = 0.0015,
+                 lambda_min:         float = 1e-12,
+                 lambda_max:         float = 5.,
+                 lagrange_ratio_max: float = 5.,
                  ):
 
         super(LatentRationaleModel, self).__init__()
@@ -63,6 +64,7 @@ class LatentRationaleModel(nn.Module):
         self.lambda_init = lambda_init
         self.lambda_min = lambda_min
         self.lambda_max = lambda_max
+        self.lagrange_ratio_max = lagrange_ratio_max
 
         self.z_rnn_size = z_rnn_size
         self.dependent_z = dependent_z
@@ -124,12 +126,14 @@ class LatentRationaleModel(nn.Module):
         self.c0_ma_eval.fill_(0.)
         self.c1_ma_eval.fill_(0.)
 
-    def update_lambda(self, i: int, ci: float):
+    def update_lambda(self, i: int, ci: float, mse: float):
         assert i == 0 or i == 1
         lambda_attr = f"lambda{i}"
         lambda_i = getattr(self, lambda_attr)
         lambda_i = lambda_i * np.exp(self.lagrange_lr * ci)
-        lambda_i = lambda_i.clamp(self.lambda_min, self.lambda_max)
+        lambda_max = self.lagrange_ratio_max * mse / (abs(ci) + 1e-12)
+        lambda_max = np.clip(lambda_max, self.lambda_min, self.lambda_max)
+        lambda_i = lambda_i.clamp(self.lambda_min, lambda_max)
         setattr(self, lambda_attr, lambda_i)
 
     def _update_ma(self, i: int, ci_hat: float):
@@ -191,7 +195,7 @@ class LatentRationaleModel(nn.Module):
 
         # update lambda
         if self.training:
-            self.update_lambda(0, c0.item())
+            self.update_lambda(0, c0.item(), mse.item())
 
         with torch.no_grad():
             optional["cost0_l0"] = l0.item()
@@ -235,7 +239,7 @@ class LatentRationaleModel(nn.Module):
 
         # update lambda
         if self.training:
-            self.update_lambda(1, c1.item())
+            self.update_lambda(1, c1.item(), mse.item())
 
         with torch.no_grad():
             optional["cost1_lasso"] = lasso_cost.item()

--- a/latent_rationale/beer/models/latent.py
+++ b/latent_rationale/beer/models/latent.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import numpy as np
 import torch
 from torch import nn
 from latent_rationale.common.util import get_z_stats
@@ -86,6 +87,8 @@ class LatentRationaleModel(nn.Module):
         self.register_buffer('lambda1', torch.full((1,), lambda_init))
         self.register_buffer('c0_ma', torch.full((1,), 0.))  # moving average
         self.register_buffer('c1_ma', torch.full((1,), 0.))  # moving average
+        self.register_buffer('c0_ma_eval', torch.full((1,), 0.))
+        self.register_buffer('c1_ma_eval', torch.full((1,), 0.))
 
     @property
     def z(self):
@@ -112,6 +115,30 @@ class LatentRationaleModel(nn.Module):
         y = self.classifier(x, mask, z)
 
         return y
+
+    def eval(self):
+        """
+        Override eval to additionally reset the moving averages
+        """
+        super(LatentRationaleModel, self).eval()
+        self.c0_ma_eval.fill_(0.)
+        self.c1_ma_eval.fill_(0.)
+
+    def update_lambda(self, i: int, ci: float):
+        assert i == 0 or i == 1
+        lambda_attr = f"lambda{i}"
+        lambda_i = getattr(self, lambda_attr)
+        lambda_i = lambda_i * np.exp(self.lagrange_lr * ci)
+        lambda_i = lambda_i.clamp(self.lambda_min, self.lambda_max)
+        setattr(self, lambda_attr, lambda_i)
+
+    def _update_ma(self, i: int, ci_hat: float):
+        assert i == 0 or i == 1
+        ma_attr = f"c{i}_ma" if self.training else f"c{i}_ma_eval"
+        ma = getattr(self, ma_attr)
+        ma = self.alpha * ma + (1-self.alpha) * ci_hat
+        setattr(self, ma_attr, ma)
+        return ma
 
     def get_loss(self, preds, targets, mask=None):
 
@@ -157,14 +184,14 @@ class LatentRationaleModel(nn.Module):
         c0_hat = (l0 - self.selection)
 
         # moving average of the constraint
-        self.c0_ma = self.alpha * self.c0_ma + (1-self.alpha) * c0_hat.item()
+        c0_ma = self._update_ma(0, c0_hat.item())
 
         # compute smoothed constraint (equals moving average c0_ma)
-        c0 = c0_hat + (self.c0_ma.detach() - c0_hat.detach())
+        c0 = c0_hat + (c0_ma.detach() - c0_hat.detach())
 
         # update lambda
-        self.lambda0 = self.lambda0 * torch.exp(self.lagrange_lr * c0.detach())
-        self.lambda0 = self.lambda0.clamp(self.lambda_min, self.lambda_max)
+        if self.training:
+            self.update_lambda(0, c0.item())
 
         with torch.no_grad():
             optional["cost0_l0"] = l0.item()
@@ -201,15 +228,14 @@ class LatentRationaleModel(nn.Module):
         c1_hat = (lasso_cost - target1)
 
         # update moving average
-        self.c1_ma = self.alpha * self.c1_ma + \
-            (1 - self.alpha) * c1_hat.detach()
+        c1_ma = self._update_ma(1, c1_hat.item())
 
         # compute smoothed constraint
-        c1 = c1_hat + (self.c1_ma.detach() - c1_hat.detach())
+        c1 = c1_hat + (c1_ma.detach() - c1_hat.detach())
 
         # update lambda
-        self.lambda1 = self.lambda1 * torch.exp(self.lagrange_lr * c1.detach())
-        self.lambda1 = self.lambda1.clamp(self.lambda_min, self.lambda_max)
+        if self.training:
+            self.update_lambda(1, c1.item())
 
         with torch.no_grad():
             optional["cost1_lasso"] = lasso_cost.item()

--- a/latent_rationale/beer/models/model_helpers.py
+++ b/latent_rationale/beer/models/model_helpers.py
@@ -41,6 +41,7 @@ def build_model(model_type, vocab, cfg=None):
         lambda_init = cfg["lambda_init"]
         lambda_min = cfg["lambda_min"]
         lambda_max = cfg["lambda_max"]
+        lagrange_ratio_max = cfg["lagrange_ratio_max"]
         return LatentRationaleModel(
             vocab_size=vocab_size, emb_size=emb_size, hidden_size=hidden_size,
             output_size=output_size, vocab=vocab, dropout=dropout,
@@ -48,6 +49,7 @@ def build_model(model_type, vocab, cfg=None):
             selection=selection, lasso=lasso,
             lagrange_alpha=lagrange_alpha, lagrange_lr=lagrange_lr,
             lambda_init=lambda_init,
-            lambda_min=lambda_min, lambda_max=lambda_max)
+            lambda_min=lambda_min, lambda_max=lambda_max,
+            lagrange_ratio_max=lagrange_ratio_max)
     else:
         raise ValueError("Unknown model")

--- a/latent_rationale/beer/train.py
+++ b/latent_rationale/beer/train.py
@@ -157,6 +157,9 @@ def train():
             optimizer.step()
             iter_i += 1
 
+            hit_bad_minima = \
+                loss_optional.get("selected", 1.) < cfg["selection_lb"]
+
             # print info
             if iter_i % print_every == 0:
 
@@ -183,7 +186,7 @@ def train():
             if iter_i % iters_per_epoch == 0:
 
                 cur_lr = scheduler.optimizer.param_groups[0]["lr"]
-                if cur_lr > cfg["min_lr"]:
+                if cur_lr > cfg["min_lr"] and not hit_bad_minima:
                     if isinstance(scheduler, MultiStepLR):
                         scheduler.step()
                     elif isinstance(scheduler, ExponentialLR):
@@ -282,7 +285,7 @@ def train():
 
                 # update lr scheduler
                 if isinstance(scheduler, ReduceLROnPlateau):
-                    if iter_i > 5 * iters_per_epoch:
+                    if iter_i > 5 * iters_per_epoch and not hit_bad_minima:
                         scheduler.step(compare_obj)
 
             # done training

--- a/latent_rationale/beer/util.py
+++ b/latent_rationale/beer/util.py
@@ -298,6 +298,8 @@ def get_args():
     parser.add_argument('--lr', type=float, default=0.0004)
     parser.add_argument('--min_lr', type=float, default=5e-5)
     parser.add_argument('--lr_decay', type=float, default=0.97)
+    parser.add_argument('--selection_lb', type=float,
+                        help="stop lr-decay when selection drops too low")
     parser.add_argument('--scheduler',
                         choices=["plateau", "multistep", "exponential"],
                         default="exponential")
@@ -349,4 +351,7 @@ def get_args():
                              "Note: this is the final weight, not a factor.")
 
     args = parser.parse_args()
+    if args.selection_lb is None:
+        # should at least select 2 tokens
+        args.selection_lb = 2. / args.max_len
     return args

--- a/latent_rationale/beer/util.py
+++ b/latent_rationale/beer/util.py
@@ -321,6 +321,8 @@ def get_args():
                         help="minimum value lambda is allowed to take")
     parser.add_argument('--lambda_max', type=float, default=5.,
                         help="maximum value lambda is allowed to take")
+    parser.add_argument('--lagrange_ratio_max', type=float, default=5.,
+                        help="maximum lagrange/mse ratio to clamp lambda to")
     parser.add_argument('--lagrange_lr', type=float, default=0.05,
                         help="learning rate for lagrange")
     parser.add_argument('--lagrange_alpha', type=float, default=0.5,


### PR DESCRIPTION
Depends on #4 

I found #4 to be kinda sufficient to get aspect 0 training stably (even with batch size 1024), but not so much for aspect 1 and 2.

One common issue seems to be the following,
model picks everything (i.e. high selection) 🡒 lambda_0 exponentially increasing 🡒 lagrange_0 suddenly dominates mse 🡒 model picks nothing (i.e. extremely low selection) 🡒 it then takes a veeery long time to escape from this particular bad local minima (esp. with learning rate already significantly decayed by then).

So this PR is trying to address this issue by
1. stopping lr-decay once "selection" drops too low (this proves very effective from the below experiments)
2. additionally clamp lambdas from above based on a maximum allowed "lagrange/mse" ratio

![image](https://user-images.githubusercontent.com/1667339/113407270-dc9b0a80-93a4-11eb-8c5b-0350c423d594.png)
